### PR TITLE
Add api token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jq, curl, Jenkins
 
 Extremely simple, use as follows:
 
-`remote-job.sh -u https://jenkins-url.com -j JOB_NAME -p "PARAM1=999" -p "PARAM2=123" -t BUILD_TOKEN -i`
+`remote-job.sh -u https://jenkins-url.com -j JOB_NAME -p "PARAM1=999" -p "PARAM2=123" -t BUILD_TOKEN -s JENKINS_USER -r APITOKEN -i`
 
 Where the following parameters are set:
 
@@ -22,6 +22,8 @@ Where the following parameters are set:
 * `-j`: JOB_NAME on jenkins host (eg master-build).
 * `-p`: parameter(s) to pass in. Send multiple parameters by passing in multiple `-p` flags.
 * `-t`: BUILD_TOKEN on remote machine to run job
+* `-s`: Jenkins user on remote machine to authenticate
+* `-r`: Jenkins user API token on remote machine to authenticate
 * `-i`: ignore certificate validation (useful if you see curl SSL errors while polling)
 
 You can optionally set the polling interval (`POLL_INTERVAL`, default 5) and build timeout (`BUILD_TIMEOUT_SECONDS`, default 3600) as environment variables.

--- a/remote-job.sh
+++ b/remote-job.sh
@@ -2,13 +2,17 @@
 ###
 # Trigger a Remote Jenkins Job with parameters and get console output as well as result
 # Usage:
-# remote-job.sh -u https://jenkins-url.com -j JOB_NAME -p "PARAM1=999" -p "PARAM2=123" -t BUILD_TOKEN
+# remote-job.sh -u https://jenkins-url.com -j JOB_NAME -t BUILD_TOKEN -s JENKINS_USER -r API_TOKEN -p "PARAM1=999" -p "PARAM2=123"
 # -u: url of jenkins host
 # -j: JOB_NAME on jenkins host
 # -p: parameter to pass in. Send multiple parameters by passing in multiple -p flags
 # -t: BUILD_TOKEN on remote machine to run job
+# -s: Jenkins user on remote machine to authenticate
+# -r: Jenkins user API token on remote machine to authenticate
 # -i: Tell curl to ignore cert validation
 ###
+
+set -xe
 
 # Number of seconds before timing out
 [ -z "$BUILD_TIMEOUT_SECONDS" ] && BUILD_TIMEOUT_SECONDS=3600
@@ -28,31 +32,31 @@ while getopts j:p:t:u:s:r:i opt; do
 done
 shift $((OPTIND -1))
 
-[ -z "$JENKINS_URL" ] && { echo "JENKINS_URL (-u) not set"; exit 1; }
-echo "[INFO] JENKINS_URL: $JENKINS_URL"
-[ -z "$JOB_NAME" ] && { echo "JOB_NAME (-j) not set"; exit 1; }
-echo "[INFO] JOB_NAME: $JOB_NAME"
+[ -z "$JENKINS_URL" ] && { logger -s "[ERROR] $(date) JENKINS_URL (-u) not set"; exit 1; }
+logger -s "[INFO] $(date) JENKINS_URL: $JENKINS_URL"
+[ -z "$JOB_NAME" ] && { logger -s "[ERROR] $(date) JOB_NAME (-j) not set"; exit 1; }
+logger -s "[INFO] $(date) JOB_NAME: $JOB_NAME"
 
-echo "The whole list of values is '${parameters[@]}'"
+logger -s "[INFO] $(date) The whole list of values is '${parameters[@]}'"
 for parameter in "${parameters[@]}"; do
   # If PARAMS exists, add an ampersand
   [ -n "$PARAMS" ] && PARAMS=$PARAMS\&$parameter
   # If no PARAMS exist, don't add an ampersand
   [ -z "$PARAMS" ] && PARAMS=$parameter
 done
-[ -z "$PARAMS" ] && { echo "[ERROR] No parameters were set!"; exit 1; }
-echo "[INFO] PARAMS: $PARAMS"
+[ -z "$PARAMS" ] && { logger -s "[ERROR] $(date) No parameters were set!"; exit 1; }
+logger -s "[INFO] $(date) PARAMS: $PARAMS"
 
 # Queue up the job
 # nb You must use the buildWithParameters build invocation as this
 # is the only mechanism of receiving the "Queued" job id (via HTTP Location header)
 
 REMOTE_JOB_URL="$JENKINS_URL/job/$JOB_NAME/buildWithParameters?$PARAMS"
-echo "[INFO] Calling REMOTE_JOB_URL: $REMOTE_JOB_URL"
+logger -s "[INFO] $(date) Calling REMOTE_JOB_URL: $REMOTE_JOB_URL"
 
 QUEUED_URL=$(curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $CURL_OPTS -D - "$REMOTE_JOB_URL" | grep Location | awk {'print $2'})
 #perl -n -e '/^Location: (.*)$/ && print "$1\n"')
-[ -z "$QUEUED_URL" ] && { echo "[ERROR] No QUEUED_URL was found.  Did you remember to set a token (-t)?"; exit 1; }
+[ -z "$QUEUED_URL" ] && { logger -s "[ERROR] $(date) No QUEUED_URL was found.  Did you remember to set a token (-t)?"; exit 1; }
 
 # Remove extra \r at end, add /api/json path
 QUEUED_URL=${QUEUED_URL%$'\r'}api/json
@@ -63,7 +67,7 @@ JOB_URL=`curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $QUEUED_URL | jq -r '.
 # Check for status of queued job, whether it is running yet
 COUNTER=0
 while [ -z "$JOB_URL" ]; do
-  echo "[INFO] The QUEUED counter is $COUNTER"
+  logger -s "[INFO] $(date) The QUEUED counter is $COUNTER"
   let COUNTER=COUNTER+$POLL_INTERVAL
   sleep $POLL_INTERVAL
   if [ "$COUNTER" -gt $BUILD_TIMEOUT_SECONDS ];
@@ -73,7 +77,7 @@ while [ -z "$JOB_URL" ]; do
   JOB_URL=`curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $CURL_OPTS $QUEUED_URL | jq -r '.executable.url'`
   [ "$JOB_URL" = "null" ] && unset JOB_URL
 done
-echo "[INFO] JOB_URL: $JOB_URL"
+logger -s "[INFO] $(date) JOB_URL: $JOB_URL"
 
 # Job is running
 IS_BUILDING="true"
@@ -88,7 +92,7 @@ until [ "$IS_BUILDING" = "false" ]; do
   sleep $POLL_INTERVAL
   if [ "$COUNTER" -gt $BUILD_TIMEOUT_SECONDS ];
   then
-    echo "[ERROR] TIME-OUT: Exceeded $BUILD_TIMEOUT_SECONDS seconds"
+    logger -s "[ERROR] $(date) TIME-OUT: Exceeded $BUILD_TIMEOUT_SECONDS seconds"
     break  # Skip entire rest of loop.
   fi
   IS_BUILDING=`curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $CURL_OPTS $JOB_URL/api/json | jq -r '.building'`
@@ -106,9 +110,9 @@ done
 RESULT=`curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $CURL_OPTS $JOB_URL/api/json | jq -r '.result'`
 if [ "$RESULT" = 'SUCCESS' ]
 then
-  echo "[INFO] BUILD RESULT: $RESULT"
+  logger -s "[INFO] $(date) BUILD RESULT: $RESULT"
   exit 0
 else
-  echo "[ERROR] BUILD RESULT: $RESULT - Build is unsuccessful, timed out, or status could not be obtained."
+  logger -s "[ERROR] $(date) BUILD RESULT: $RESULT - Build is unsuccessful, timed out, or status could not be obtained."
   exit 1
 fi

--- a/remote-job.sh
+++ b/remote-job.sh
@@ -12,7 +12,7 @@
 # -i: Tell curl to ignore cert validation
 ###
 
-set -xe
+set -e
 
 # Number of seconds before timing out
 [ -z "$BUILD_TIMEOUT_SECONDS" ] && BUILD_TIMEOUT_SECONDS=3600

--- a/remote-job.sh
+++ b/remote-job.sh
@@ -14,12 +14,14 @@
 [ -z "$BUILD_TIMEOUT_SECONDS" ] && BUILD_TIMEOUT_SECONDS=3600
 # Number of seconds between polling attempts
 [ -z "$POLL_INTERVAL" ] && POLL_INTERVAL=10
-while getopts j:p:t:u:i opt; do
+while getopts j:p:t:u:s:r:i opt; do
   case $opt in
     p) parameters+=("$OPTARG");;
     t) parameters+=("token=$OPTARG");;
     j) JOB_NAME=$OPTARG;;
     u) JENKINS_URL=$OPTARG;;
+    s) JENKINS_USER=$OPTARG;;
+    r) API_TOKEN=$OPTARG;;
     i) CURL_OPTS="-k" # tell curl to ignore cert validation
     #...
   esac
@@ -27,9 +29,9 @@ done
 shift $((OPTIND -1))
 
 [ -z "$JENKINS_URL" ] && { echo "JENKINS_URL (-u) not set"; exit 1; }
-echo "JENKINS_URL: $JENKINS_URL"
+echo "[INFO] JENKINS_URL: $JENKINS_URL"
 [ -z "$JOB_NAME" ] && { echo "JOB_NAME (-j) not set"; exit 1; }
-echo "JOB_NAME: $JOB_NAME"
+echo "[INFO] JOB_NAME: $JOB_NAME"
 
 echo "The whole list of values is '${parameters[@]}'"
 for parameter in "${parameters[@]}"; do
@@ -38,40 +40,40 @@ for parameter in "${parameters[@]}"; do
   # If no PARAMS exist, don't add an ampersand
   [ -z "$PARAMS" ] && PARAMS=$parameter
 done
-[ -z "$PARAMS" ] && { echo "No parameters were set!"; exit 1; }
-echo "PARAMS: $PARAMS"
+[ -z "$PARAMS" ] && { echo "[ERROR] No parameters were set!"; exit 1; }
+echo "[INFO] PARAMS: $PARAMS"
 
 # Queue up the job
 # nb You must use the buildWithParameters build invocation as this
 # is the only mechanism of receiving the "Queued" job id (via HTTP Location header)
 
 REMOTE_JOB_URL="$JENKINS_URL/job/$JOB_NAME/buildWithParameters?$PARAMS"
-echo "Calling REMOTE_JOB_URL: $REMOTE_JOB_URL"
+echo "[INFO] Calling REMOTE_JOB_URL: $REMOTE_JOB_URL"
 
-QUEUED_URL=$(curl -sSL $CURL_OPTS -D - $REMOTE_JOB_URL |\
-perl -n -e '/^Location: (.*)$/ && print "$1\n"')
-[ -z "$QUEUED_URL" ] && { echo "No QUEUED_URL was found.  Did you remember to set a token (-t)?"; exit 1; }
+QUEUED_URL=$(curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $CURL_OPTS -D - "$REMOTE_JOB_URL" | grep Location | awk {'print $2'})
+#perl -n -e '/^Location: (.*)$/ && print "$1\n"')
+[ -z "$QUEUED_URL" ] && { echo "[ERROR] No QUEUED_URL was found.  Did you remember to set a token (-t)?"; exit 1; }
 
 # Remove extra \r at end, add /api/json path
 QUEUED_URL=${QUEUED_URL%$'\r'}api/json
 
 # Fetch the executable.url from the QUEUED url
-JOB_URL=`curl -sSL $QUEUED_URL | jq -r '.executable.url'`
+JOB_URL=`curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $QUEUED_URL | jq -r '.executable.url'`
 [ "$JOB_URL" = "null" ] && unset JOB_URL
 # Check for status of queued job, whether it is running yet
 COUNTER=0
 while [ -z "$JOB_URL" ]; do
-  echo "The QUEUED counter is $COUNTER"
+  echo "[INFO] The QUEUED counter is $COUNTER"
   let COUNTER=COUNTER+$POLL_INTERVAL
   sleep $POLL_INTERVAL
   if [ "$COUNTER" -gt $BUILD_TIMEOUT_SECONDS ];
   then
     break  # Skip entire rest of loop.
   fi
-  JOB_URL=`curl -sSL $CURL_OPTS $QUEUED_URL | jq -r '.executable.url'`
+  JOB_URL=`curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $CURL_OPTS $QUEUED_URL | jq -r '.executable.url'`
   [ "$JOB_URL" = "null" ] && unset JOB_URL
 done
-echo "JOB_URL: $JOB_URL"
+echo "[INFO] JOB_URL: $JOB_URL"
 
 # Job is running
 IS_BUILDING="true"
@@ -86,27 +88,27 @@ until [ "$IS_BUILDING" = "false" ]; do
   sleep $POLL_INTERVAL
   if [ "$COUNTER" -gt $BUILD_TIMEOUT_SECONDS ];
   then
-    echo "TIME-OUT: Exceeded $BUILD_TIMEOUT_SECONDS seconds"
+    echo "[ERROR] TIME-OUT: Exceeded $BUILD_TIMEOUT_SECONDS seconds"
     break  # Skip entire rest of loop.
   fi
-  IS_BUILDING=`curl -sSL $CURL_OPTS $JOB_URL/api/json | jq -r '.building'`
+  IS_BUILDING=`curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $CURL_OPTS $JOB_URL/api/json | jq -r '.building'`
   # Grab total lines in console output
-  NEW_LINE_CURSOR=`curl -sSL $CURL_OPTS $JOB_URL/consoleText | wc -l`
+  NEW_LINE_CURSOR=`curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $CURL_OPTS $JOB_URL/consoleText | wc -l`
   # subtract line count from cursor
   LINE_COUNT=`expr $NEW_LINE_CURSOR - $OUTPUT_LINE_CURSOR`
   if [ "$LINE_COUNT" -gt 0 ];
   then
-    curl -sSL $JOB_URL/consoleText | tail -$LINE_COUNT
+    curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $JOB_URL/consoleText | tail -$LINE_COUNT
   fi
   OUTPUT_LINE_CURSOR=$NEW_LINE_CURSOR
 done
 
-RESULT=`curl -sSL $CURL_OPTS $JOB_URL/api/json | jq -r '.result'`
+RESULT=`curl -XPOST -sSL --user $JENKINS_USER:$API_TOKEN $CURL_OPTS $JOB_URL/api/json | jq -r '.result'`
 if [ "$RESULT" = 'SUCCESS' ]
 then
-  echo "BUILD RESULT: $RESULT"
+  echo "[INFO] BUILD RESULT: $RESULT"
   exit 0
 else
-  echo "BUILD RESULT: $RESULT - Build is unsuccessful, timed out, or status could not be obtained."
+  echo "[ERROR] BUILD RESULT: $RESULT - Build is unsuccessful, timed out, or status could not be obtained."
   exit 1
 fi

--- a/remote-job.sh
+++ b/remote-job.sh
@@ -35,6 +35,7 @@ shift $((OPTIND -1))
 [ -z "$JENKINS_URL" ] && { logger -s "[ERROR] $(date) JENKINS_URL (-u) not set"; exit 1; }
 logger -s "[INFO] $(date) JENKINS_URL: $JENKINS_URL"
 [ -z "$JOB_NAME" ] && { logger -s "[ERROR] $(date) JOB_NAME (-j) not set"; exit 1; }
+$JOB_NAME=${JOB_NAME// /%20}
 logger -s "[INFO] $(date) JOB_NAME: $JOB_NAME"
 
 logger -s "[INFO] $(date) The whole list of values is '${parameters[@]}'"

--- a/remote-job.sh
+++ b/remote-job.sh
@@ -35,7 +35,7 @@ shift $((OPTIND -1))
 [ -z "$JENKINS_URL" ] && { logger -s "[ERROR] $(date) JENKINS_URL (-u) not set"; exit 1; }
 logger -s "[INFO] $(date) JENKINS_URL: $JENKINS_URL"
 [ -z "$JOB_NAME" ] && { logger -s "[ERROR] $(date) JOB_NAME (-j) not set"; exit 1; }
-$JOB_NAME=${JOB_NAME// /%20}
+JOB_NAME=${JOB_NAME// /%20}
 logger -s "[INFO] $(date) JOB_NAME: $JOB_NAME"
 
 logger -s "[INFO] $(date) The whole list of values is '${parameters[@]}'"


### PR DESCRIPTION
Clients should be able to run jobs on Jenkins with a user and its API token. Also instead of `echo` using `logger` to log the actions might be better.